### PR TITLE
Fix memory leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,16 +9,17 @@ pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/$
  * @returns {Promise<string>} A promise that resolves with the extracted text content.
  */
 const pdfToText = async (file) => {
+
+    // Create a blob URL for the PDF file
+    const blobUrl = URL.createObjectURL(file)
+
+    // Load the PDF file
+    const loadingTask = pdfjs.getDocument(blobUrl)
+
+    let extractedText = ""
     try {
-        // Create a blob URL for the PDF file
-        const blobUrl = URL.createObjectURL(file)
-
-        // Load the PDF file
-        const loadingTask = pdfjs.getDocument(blobUrl)
-
         const pdf = await loadingTask.promise
         const numPages = pdf.numPages
-        let extractedText = ""
 
         // Iterate through each page and extract text
         for (let pageNumber = 1; pageNumber <= numPages; pageNumber++) {
@@ -27,14 +28,19 @@ const pdfToText = async (file) => {
             const pageText = textContent.items.map((item) => item.str).join(" ")
             extractedText += pageText
         }
-        if (extractedText.length > 0) {
-            return extractedText
-        }
-        console.error("Error extracting text from PDF:", error)
-
-        // Clean up the blob URL
-        URL.revokeObjectURL(blobUrl)
     } catch (error) {
+        console.error("Error extracting text from PDF:", error)
+    }
+
+    // Clean up the blob URL
+    URL.revokeObjectURL(blobUrl)
+
+    // Free memory from loading task
+    loadingTask.destroy()
+    
+    if (extractedText.length > 0) {
+        return extractedText
+    } else {
         console.error("Error extracting text from PDF:", error)
     }
 }

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const pdfToText = async (file) => {
     const loadingTask = pdfjs.getDocument(blobUrl)
 
     let extractedText = ""
+    let hadParsingError = false
     try {
         const pdf = await loadingTask.promise
         const numPages = pdf.numPages
@@ -29,6 +30,7 @@ const pdfToText = async (file) => {
             extractedText += pageText
         }
     } catch (error) {
+        hadParsingError = true
         console.error("Error extracting text from PDF:", error)
     }
 
@@ -38,10 +40,8 @@ const pdfToText = async (file) => {
     // Free memory from loading task
     loadingTask.destroy()
     
-    if (extractedText.length > 0) {
+    if (!hadParsingError) {
         return extractedText
-    } else {
-        console.error("Error extracting text from PDF:", error)
     }
 }
 


### PR DESCRIPTION
This PR fixes a couple memory leaks:

1. After creating the blob URL, we need to revoke it.
2. After calling `getDocument` to create the `loadingTask`, we need to `destroy` it to kill the JS VM that spins up.

I ran into this memory leak issue when trying to parse a few hundred PDFs. Happy to clean this PR up a bit but figured I'd at least see if this repo is open to PRs first. 