### PR TITLE
Add type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       "devDependencies": {
         "@babel/cli": "^7.24.1",
         "@babel/core": "^7.24.4",
-        "@babel/preset-env": "^7.24.4"
+        "@babel/preset-env": "^7.24.4",
+        "typescript": "^5.4.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3336,6 +3337,19 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "A simple light weight react package to extract plain text from a pdf file.",
   "main": "dist/index.js",
   "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "babel index.js -o dist/index.js",
+    "build": "babel index.js -o dist/index.js && tsc",
     "prepublishOnly": "npm run build"
   },
   "repository": {
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@babel/cli": "^7.24.1",
     "@babel/core": "^7.24.4",
-    "@babel/preset-env": "^7.24.4"
+    "@babel/preset-env": "^7.24.4",
+    "typescript": "^5.4.5"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "files": ["index.js"],
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+
+    // This matches the TypeScript target used by react-pdf:
+    // https://github.com/wojtekmaj/react-pdf/blob/main/packages/react-pdf/tsconfig.json
+    "target": "ES2015"
+  }
+}


### PR DESCRIPTION
This adds TypeScript definitions to the package. I had to manually type the package to use it in my project, so I thought this would be a little nicer.

The `index.d.ts` file is generated automatically as part of the build process using `tsc`, a minimal `tsconfig.json`, and the JSDoc annotation that's already there — figured this would be easier to maintain than a manual typedef file, but I could be wrong. I'm happy to make any changes you see fit.