### PR TITLE
Dependancy update - bug fix for possible malicious script injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
-        "react-pdf": "^8.0.2"
+        "react-pdf": "^9.1.0"
       },
       "devDependencies": {
         "typescript": "^5.4.5"
@@ -152,9 +152,9 @@
       "optional": true
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "optional": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -264,6 +264,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -303,6 +304,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "optional": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -473,9 +475,9 @@
       "optional": true
     },
     "node_modules/nan": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
-      "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
+      "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
       "optional": true
     },
     "node_modules/node-fetch": {
@@ -553,25 +555,25 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path2d-polyfill": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path2d-polyfill/-/path2d-polyfill-2.0.1.tgz",
-      "integrity": "sha512-ad/3bsalbbWhmBo0D6FZ4RNMwsLsPpL6gnvhuSaU5Vm7b06Kr5ubSltQQ0T7YKsiJQO+g22zJ4dJKNTXIyOXtA==",
+    "node_modules/path2d": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.2.1.tgz",
+      "integrity": "sha512-Fl2z/BHvkTNvkuBzYTpTuirHZg6wW9z8+4SND/3mDTEcYbbNKWAy21dz9D3ePNNwrrK8pqZO5vLPZ1hLF6T7XA==",
       "optional": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=6"
       }
     },
     "node_modules/pdfjs-dist": {
-      "version": "3.11.174",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
-      "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
+      "version": "4.4.168",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.4.168.tgz",
+      "integrity": "sha512-MbkAjpwka/dMHaCfQ75RY1FXX3IewBVu6NGZOcxerRFlaBiIkZmUoR0jotX5VUzYZEXAGzSFtknWs5xRKliXPA==",
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
         "canvas": "^2.11.2",
-        "path2d-polyfill": "^2.0.1"
+        "path2d": "^0.2.0"
       }
     },
     "node_modules/react": {
@@ -600,16 +602,16 @@
       }
     },
     "node_modules/react-pdf": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-8.0.2.tgz",
-      "integrity": "sha512-C0PFC+j9vmEIZ82Iq0c85xUWkgsZTUS05syqOk8NC+7PAanyWlVi/ImYkGQe27zYAlBA6IidRYEt1DAAXKq1Ow==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-9.1.0.tgz",
+      "integrity": "sha512-KhPDQE3QshkLdS3b48S5Bldv0N5flob6qwvsiADWdZOS5TMDaIrkRtEs+Dyl6ubRf2jTf9jWmFb6RjWu46lSSg==",
       "dependencies": {
         "clsx": "^2.0.0",
         "dequal": "^2.0.3",
         "make-cancellable-promise": "^1.3.1",
         "make-event-props": "^1.6.0",
         "merge-refs": "^1.3.0",
-        "pdfjs-dist": "3.11.174",
+        "pdfjs-dist": "4.4.168",
         "tiny-invariant": "^1.0.0",
         "warning": "^4.0.0"
       },
@@ -645,6 +647,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -686,9 +689,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "optional": true,
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "Utkarsh Pancholi",
   "license": "ISC",
   "dependencies": {
-    "react-pdf": "^8.0.2"
+    "react-pdf": "^9.1.0"
   },
   "devDependencies": {
     "typescript": "^5.4.5"


### PR DESCRIPTION
Previously, react-pdftotext relied on react-pdf version 8.0.2, which itself relies on a vulnerable version of pdfjs-dist (needs to be upgraded to at least 4.2.67), which means react-pdf needs to be upgraded to 9.0.0 or 9.1.0. This pull request updates react-pdf to 9.1.0, and pdfjs-dist to 4.4.168. 